### PR TITLE
Configure frontend deployment with backend URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         cd frontend
         npm run build
+      env:
+        REACT_APP_BACKEND_URL: https://agent-softcatala.onrender.com
 
   build-backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
       run: |
         cd frontend
         npm run build
+      env:
+        REACT_APP_BACKEND_URL: https://agent-softcatala.onrender.com
         
     - name: Setup Pages
       uses: actions/configure-pages@v4

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { ChatMessage, StreamChunk } from '../types';
 
 const API_BASE = process.env.NODE_ENV === 'production' 
-  ? window.location.origin 
+  ? (process.env.REACT_APP_BACKEND_URL || 'https://agent-softcatala.onrender.com')
   : 'http://localhost:8000';
 
 export const useChat = () => {


### PR DESCRIPTION
Configure frontend to connect to `https://agent-softcatala.onrender.com` when deployed via GitHub Actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc792011-8f2e-4035-ad1c-1abe0709f77c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc792011-8f2e-4035-ad1c-1abe0709f77c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>