### PR TITLE
Add openai provider with gpt-4.1-mini

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,12 +33,14 @@ def validate_providers():
     """Validate that at least one LLM provider is properly configured."""
     ollama_url = os.getenv("OLLAMA_URL")
     zhipu_api_key = os.getenv("ZHIPUAI_API_KEY")
+    openai_key = os.getenv("OPENAI_KEY")
     
-    if not ollama_url and not zhipu_api_key:
+    if not ollama_url and not zhipu_api_key and not openai_key:
         error_msg = (
             "No LLM providers configured. Please set at least one of:\n"
             "- OLLAMA_URL (for Ollama provider)\n"
-            "- ZHIPUAI_API_KEY (for Zhipu AI provider)"
+            "- ZHIPUAI_API_KEY (for Zhipu AI provider)\n"
+            "- OPENAI_KEY (for OpenAI provider)"
         )
         logger.error(error_msg)
         raise RuntimeError(error_msg)
@@ -49,6 +51,8 @@ def validate_providers():
         configured_providers.append(f"Ollama ({ollama_url})")
     if zhipu_api_key:
         configured_providers.append("Zhipu AI")
+    if openai_key:
+        configured_providers.append("OpenAI")
     
     logger.info(f"Configured providers: {', '.join(configured_providers)}")
 

--- a/backend/models/providers/__init__.py
+++ b/backend/models/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from .ollama_provider import OllamaProvider
 from .zhipu_provider import ZhipuProvider
+from .openai_provider import OpenAIProvider
 from .base_provider import BaseProvider
 
-__all__ = ["OllamaProvider", "ZhipuProvider", "BaseProvider"]
+__all__ = ["OllamaProvider", "ZhipuProvider", "OpenAIProvider", "BaseProvider"]

--- a/backend/models/providers/openai_provider.py
+++ b/backend/models/providers/openai_provider.py
@@ -1,0 +1,115 @@
+"""OpenAI provider implementation."""
+
+import os
+from typing import List, Dict, Any
+import logging
+
+from langchain_openai import ChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from .base_provider import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(BaseProvider):
+    """OpenAI provider for OpenAI language models."""
+    
+    def __init__(self, api_key: str = None, base_url: str = None):
+        """Initialize OpenAI provider.
+        
+        Args:
+            api_key: OpenAI API key (if not provided, will use OPENAI_KEY env var)
+            base_url: Custom base URL for OpenAI API (optional)
+        """
+        self.api_key = api_key or os.getenv("OPENAI_KEY")
+        if not self.api_key:
+            raise ValueError("OpenAI API key is required. Set OPENAI_KEY environment variable or pass api_key parameter.")
+        
+        self.base_url = base_url
+        super().__init__()
+    
+    def get_model(self, model_name: str, **kwargs) -> BaseChatModel:
+        """Get a specific OpenAI model instance.
+        
+        Args:
+            model_name: Name of the model to load
+            **kwargs: Additional parameters for the model
+            
+        Returns:
+            ChatOpenAI instance
+        """
+        model_kwargs = {
+            "model": model_name,
+            "openai_api_key": self.api_key,
+            "temperature": kwargs.get("temperature", 0.7),
+            "max_tokens": kwargs.get("max_tokens", 2048),
+            "top_p": kwargs.get("top_p", 1.0),
+        }
+        
+        if self.base_url:
+            model_kwargs["openai_api_base"] = self.base_url
+        
+        # Add any additional kwargs
+        for key, value in kwargs.items():
+            if key not in ["temperature", "max_tokens", "top_p"]:
+                model_kwargs[key] = value
+        
+        return ChatOpenAI(**model_kwargs)
+    
+    def list_models(self) -> List[str]:
+        """List available OpenAI models.
+        
+        Returns:
+            List of model names
+        """
+        # Return commonly available OpenAI models
+        # Note: OpenAI doesn't provide a public API endpoint to list all available models
+        # so we return a curated list of common models
+        return [
+            "gpt-4.1-mini",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4-turbo",
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-16k"
+        ]
+    
+    def get_default_model(self) -> BaseChatModel:
+        """Get the default OpenAI model.
+        
+        Returns:
+            ChatOpenAI instance with gpt-4.1-mini as default model
+        """
+        return self.get_model("gpt-4.1-mini")
+    
+    async def health_check(self) -> Dict[str, Any]:
+        """Check OpenAI API health.
+        
+        Returns:
+            Health status dictionary
+        """
+        try:
+            # Try to create a model instance and make a simple call to verify connectivity
+            model = self.get_model("gpt-4.1-mini")
+            
+            # Test with a minimal request
+            test_response = await model.ainvoke("Hello")
+            
+            return {
+                "status": "healthy",
+                "provider": "openai",
+                "default_model": "gpt-4.1-mini",
+                "api_key_configured": bool(self.api_key),
+                "base_url": self.base_url or "https://api.openai.com/v1",
+                "available_models_count": len(self.list_models())
+            }
+        except Exception as e:
+            return {
+                "status": "unhealthy",
+                "provider": "openai",
+                "error": str(e),
+                "api_key_configured": bool(self.api_key),
+                "base_url": self.base_url or "https://api.openai.com/v1"
+            }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,7 +20,8 @@ PyPDF2==3.0.1
 python-telegram-bot==21.0.1
 
 # LangChain dependencies
-langchain-core==0.2.38
+langchain-core==0.2.40
 langchain==0.2.16
 langchain-community==0.2.16
 langchain-ollama==0.1.3
+langchain-openai==0.1.25

--- a/backend/tests/test_openai_provider.py
+++ b/backend/tests/test_openai_provider.py
@@ -1,0 +1,178 @@
+"""Tests for OpenAI provider implementation."""
+
+import pytest
+import os
+from unittest.mock import Mock, patch, AsyncMock
+from typing import List
+
+from langchain_core.messages import HumanMessage, AIMessage
+from langchain_openai import ChatOpenAI
+
+from models.providers.openai_provider import OpenAIProvider
+from models.providers.base_provider import BaseProvider
+
+
+class TestOpenAIProvider:
+    """Test suite for OpenAI provider functionality."""
+
+    @pytest.fixture
+    def openai_provider(self):
+        """Create an OpenAIProvider instance for testing."""
+        return OpenAIProvider(api_key="test_api_key")
+
+    @pytest.fixture
+    def sample_messages(self):
+        """Sample messages for testing."""
+        return [HumanMessage(content="Hello, how are you?")]
+
+    def test_openai_provider_initialization(self, openai_provider):
+        """Test that OpenAIProvider initializes correctly."""
+        assert isinstance(openai_provider, BaseProvider)
+        assert openai_provider.api_key == "test_api_key"
+        assert openai_provider.base_url is None
+
+    def test_openai_provider_initialization_with_base_url(self):
+        """Test that OpenAIProvider initializes correctly with custom base URL."""
+        provider = OpenAIProvider(api_key="test_api_key", base_url="https://custom.openai.com/v1")
+        assert provider.api_key == "test_api_key"
+        assert provider.base_url == "https://custom.openai.com/v1"
+
+    @patch.dict(os.environ, {'OPENAI_KEY': 'env_api_key'})
+    def test_openai_provider_initialization_from_env(self):
+        """Test that OpenAIProvider initializes from environment variable."""
+        provider = OpenAIProvider()
+        assert provider.api_key == "env_api_key"
+
+    def test_openai_provider_initialization_no_api_key(self):
+        """Test that OpenAIProvider raises error when no API key is provided."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="OpenAI API key is required"):
+                OpenAIProvider()
+
+    def test_get_model(self, openai_provider):
+        """Test getting an OpenAI model."""
+        model = openai_provider.get_model("gpt-4.1-mini")
+        assert isinstance(model, ChatOpenAI)
+        assert model.model_name == "gpt-4.1-mini"
+        assert model.openai_api_key.get_secret_value() == "test_api_key"
+
+    def test_get_model_with_parameters(self, openai_provider):
+        """Test getting an OpenAI model with custom parameters."""
+        model = openai_provider.get_model(
+            "gpt-4o", 
+            temperature=0.5, 
+            max_tokens=1000,
+            top_p=0.9
+        )
+        assert isinstance(model, ChatOpenAI)
+        assert model.model_name == "gpt-4o"
+        assert model.temperature == 0.5
+        assert model.max_tokens == 1000
+        assert model.top_p == 0.9
+
+    def test_get_model_with_base_url(self):
+        """Test getting an OpenAI model with custom base URL."""
+        provider = OpenAIProvider(api_key="test_key", base_url="https://custom.openai.com/v1")
+        model = provider.get_model("gpt-4.1-mini")
+        assert isinstance(model, ChatOpenAI)
+        assert model.openai_api_base == "https://custom.openai.com/v1"
+
+    def test_list_models(self, openai_provider):
+        """Test that available models are returned."""
+        models = openai_provider.list_models()
+        assert isinstance(models, list)
+        assert len(models) > 0
+        assert "gpt-4.1-mini" in models
+        assert "gpt-4o" in models
+        assert "gpt-3.5-turbo" in models
+
+    def test_get_default_model(self, openai_provider):
+        """Test getting the default model."""
+        model = openai_provider.get_default_model()
+        assert isinstance(model, ChatOpenAI)
+        assert model.model_name == "gpt-4.1-mini"
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self, openai_provider):
+        """Test successful health check."""
+        # Mock the model's ainvoke method
+        with patch.object(openai_provider, 'get_model') as mock_get_model:
+            mock_model = AsyncMock()
+            mock_model.ainvoke.return_value = AIMessage(content="Hello!")
+            mock_get_model.return_value = mock_model
+            
+            health = await openai_provider.health_check()
+            
+            assert health["status"] == "healthy"
+            assert health["provider"] == "openai"
+            assert health["default_model"] == "gpt-4.1-mini"
+            assert health["api_key_configured"] is True
+            assert health["base_url"] == "https://api.openai.com/v1"
+            assert health["available_models_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self, openai_provider):
+        """Test health check failure."""
+        # Mock the model's ainvoke method to raise an exception
+        with patch.object(openai_provider, 'get_model') as mock_get_model:
+            mock_model = AsyncMock()
+            mock_model.ainvoke.side_effect = Exception("API error")
+            mock_get_model.return_value = mock_model
+            
+            health = await openai_provider.health_check()
+            
+            assert health["status"] == "unhealthy"
+            assert health["provider"] == "openai"
+            assert "error" in health
+            assert health["api_key_configured"] is True
+            assert health["base_url"] == "https://api.openai.com/v1"
+
+    @pytest.mark.asyncio
+    async def test_health_check_with_custom_base_url(self):
+        """Test health check with custom base URL."""
+        provider = OpenAIProvider(api_key="test_key", base_url="https://custom.openai.com/v1")
+        
+        with patch.object(provider, 'get_model') as mock_get_model:
+            mock_model = AsyncMock()
+            mock_model.ainvoke.return_value = AIMessage(content="Hello!")
+            mock_get_model.return_value = mock_model
+            
+            health = await provider.health_check()
+            
+            assert health["status"] == "healthy"
+            assert health["base_url"] == "https://custom.openai.com/v1"
+
+
+class TestOpenAIProviderIntegration:
+    """Integration tests for OpenAIProvider with other components."""
+    
+    @pytest.mark.skipif(
+        not os.getenv("OPENAI_KEY"),
+        reason="OPENAI_KEY environment variable not set"
+    )
+    @pytest.mark.asyncio
+    async def test_real_openai_api_call(self):
+        """Test real OpenAI API call (only when API key is available)."""
+        provider = OpenAIProvider()
+        model = provider.get_model("gpt-4.1-mini", temperature=0.1, max_tokens=50)
+        
+        # Make a simple API call
+        response = await model.ainvoke([HumanMessage(content="Say 'Hello, World!' and nothing else.")])
+        
+        assert isinstance(response, AIMessage)
+        assert len(response.content) > 0
+        assert "Hello" in response.content
+
+    @pytest.mark.skipif(
+        not os.getenv("OPENAI_KEY"),
+        reason="OPENAI_KEY environment variable not set"
+    )
+    @pytest.mark.asyncio
+    async def test_real_health_check(self):
+        """Test real health check (only when API key is available)."""
+        provider = OpenAIProvider()
+        health = await provider.health_check()
+        
+        assert health["status"] == "healthy"
+        assert health["provider"] == "openai"
+        assert health["api_key_configured"] is True


### PR DESCRIPTION
Adds OpenAI as a new LLM provider with `gpt-4.1-mini` as the default model and comprehensive test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-89189151-a367-44c4-841b-54b68b4f89ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89189151-a367-44c4-841b-54b68b4f89ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

