### PR TITLE
Improve gemma catalan language prompts

### DIFF
--- a/backend/tools/catalan_spell_checker.py
+++ b/backend/tools/catalan_spell_checker.py
@@ -38,6 +38,29 @@ class CatalanSpellCheckerTool(BaseTool):
             ]
         )
     
+    @property
+    def catalan_definition(self) -> ToolDefinition:
+        """Catalan version of the tool definition for use with Catalan prompts"""
+        return ToolDefinition(
+            name="catalan_spell_checker",
+            description="Comprova textos catalans per detectar errors d'ortografia, gramàtica i estil. Suporta el català central (general), el valencià i el balear. Retorna informació detallada dels errors amb suggeriments de correcció.",
+            parameters=[
+                ToolParameter(
+                    name="text",
+                    type="string",
+                    description="El text català a comprovar per detectar errors d'ortografia i gramàtica",
+                    required=True
+                ),
+                ToolParameter(
+                    name="dialect",
+                    type="string",
+                    description="Dialecte català a utilitzar: 'general' per al dialecte català central, 'valencia' per al valencià, o 'balear' per al balear. Si no s'especifica, l'eina detectarà automàticament el dialecte apropiat.",
+                    required=False,
+                    default="auto"
+                )
+            ]
+        )
+    
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """Execute the spell checking"""
         self.validate_parameters(kwargs)

--- a/backend/tools/catalan_synonyms.py
+++ b/backend/tools/catalan_synonyms.py
@@ -43,6 +43,35 @@ class CatalanSynonymsTool(BaseTool):
             ]
         )
     
+    @property
+    def catalan_definition(self) -> ToolDefinition:
+        """Catalan version of the tool definition for use with Catalan prompts"""
+        return ToolDefinition(
+            name="catalan_synonyms",
+            description="Cerca sinònims, antònims i paraules relacionades al diccionari de la llengua catalana. Suporta cerca de paraules, autocompletat i consulta d'índex de paraules.",
+            parameters=[
+                ToolParameter(
+                    name="action",
+                    type="string",
+                    description="Acció a realitzar: 'search' (obtenir sinònims d'una paraula), 'autocomplete' (obtenir suggeriments de paraules), o 'index' (obtenir paraules que comencen amb un prefix)",
+                    required=True
+                ),
+                ToolParameter(
+                    name="word",
+                    type="string", 
+                    description="La paraula catalana per la qual cercar sinònims, suggeriments d'autocompletat, o usar com a prefix per a la consulta d'índex",
+                    required=True
+                ),
+                ToolParameter(
+                    name="max_results",
+                    type="integer",
+                    description="Nombre màxim de resultats a retornar per a les operacions d'autocompletat i índex",
+                    required=False,
+                    default=10
+                )
+            ]
+        )
+    
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """Execute the synonyms search"""
         self.validate_parameters(kwargs)

--- a/backend/tools/langchain_tools.py
+++ b/backend/tools/langchain_tools.py
@@ -16,16 +16,21 @@ class LangChainToolWrapper(BaseTool):
     description: str = Field(description="The description of the tool")
     custom_tool: CustomBaseTool = Field(description="The wrapped custom tool")
     
-    def __init__(self, custom_tool: CustomBaseTool, **kwargs):
+    def __init__(self, custom_tool: CustomBaseTool, use_catalan: bool = False, **kwargs):
         """Initialize the wrapper with a custom tool.
         
         Args:
             custom_tool: The custom tool to wrap
+            use_catalan: Whether to use Catalan tool descriptions
         """
-        tool_def = custom_tool.definition
+        # Use Catalan definition if available and requested
+        if use_catalan and hasattr(custom_tool, 'catalan_definition'):
+            tool_def = custom_tool.catalan_definition
+        else:
+            tool_def = custom_tool.definition
         
         # Generate the schema before calling super()
-        schema = self._generate_args_schema(custom_tool)
+        schema = self._generate_args_schema(custom_tool, use_catalan)
         
         super().__init__(
             name=tool_def.name,
@@ -119,13 +124,17 @@ class LangChainToolWrapper(BaseTool):
             logger.info(f"🔧 Returning error details for {self.name}: {error_details}")
             return error_details
     
-    def _generate_args_schema(self, custom_tool: CustomBaseTool) -> Optional[Type[BaseModel]]:
+    def _generate_args_schema(self, custom_tool: CustomBaseTool, use_catalan: bool = False) -> Optional[Type[BaseModel]]:
         """Generate the arguments schema for the tool during initialization."""
         import logging
         logger = logging.getLogger(__name__)
         
         # Dynamically create a Pydantic model based on tool parameters
-        tool_def = custom_tool.definition
+        # Use Catalan definition if available and requested
+        if use_catalan and hasattr(custom_tool, 'catalan_definition'):
+            tool_def = custom_tool.catalan_definition
+        else:
+            tool_def = custom_tool.definition
         
         if not tool_def.parameters:
             return None


### PR DESCRIPTION
Ensures Gemma 3 consistently speaks Catalan by providing Catalan tool descriptions and reinforcing language constraints.

The model was reverting to English because tool descriptions, even when using a Catalan system prompt, were in English, creating a mixed-language context. This PR translates tool descriptions to Catalan, strengthens language directives in both English and Catalan prompts, and adds a post-processing step to detect and flag English output, ensuring a fully consistent Catalan environment for the model.

---
<a href="https://cursor.com/background-agent?bcId=bc-5972e00c-3c10-4910-bdf3-b4e5fdd0c623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5972e00c-3c10-4910-bdf3-b4e5fdd0c623">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

