### PR TITLE
Set up GitHub CI health check cronjob

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,28 @@
+name: Health Check
+
+on:
+  schedule:
+    # Run every 10 minutes
+    - cron: '*/10 * * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Ping Health Endpoint
+      run: |
+        echo "Pinging health endpoint..."
+        response=$(curl -s -o /dev/null -w "%{http_code}" https://agent-softcatala.onrender.com/health)
+        echo "Health check response code: $response"
+        
+        if [ "$response" -eq 200 ]; then
+          echo "✅ Health check passed"
+        else
+          echo "❌ Health check failed with status code: $response"
+          exit 1
+        fi
+    
+    - name: Log timestamp
+      run: echo "Health check completed at $(date -u)"


### PR DESCRIPTION
Add a GitHub CI cronjob to ping the health endpoint every 10 minutes to keep the service active and monitor availability.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2920311-f3ca-4560-82d4-5300a3b87c14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2920311-f3ca-4560-82d4-5300a3b87c14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

