### PR TITLE
Fix model switch prompt variable error

### DIFF
--- a/backend/langchain_agent.py
+++ b/backend/langchain_agent.py
@@ -317,6 +317,11 @@ Si un usuari pregunta com pot col·laborar amb Softcatalà, explica'li que la mi
                 "chat_history": chat_history
             }
             
+            # Add agent_scratchpad only if we're using an AgentExecutor (not for simple chains)
+            # This fixes the issue when switching between native tool-calling and fallback models
+            if isinstance(self.agent_executor, AgentExecutor):
+                agent_input["agent_scratchpad"] = []
+            
             # Configure comprehensive logging with streaming callback
             streaming_callback = StreamingCallbackHandler(
                 lambda chunk: self._emit_chunk(chunk)


### PR DESCRIPTION
Fix streaming error by conditionally adding `agent_scratchpad` to agent input based on agent type.

This resolves an issue where switching from a native tool-calling model to a non-tool-calling model caused a `ChatPromptTemplate` error due to a missing `agent_scratchpad` variable. The `agent_scratchpad` is now only included when the `AgentExecutor` (used for tool-calling models) is active.

---
<a href="https://cursor.com/background-agent?bcId=bc-051b3fe4-2c1a-403a-9fcd-e8814f0b8f60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-051b3fe4-2c1a-403a-9fcd-e8814f0b8f60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

