### PR TITLE
Fix cors issues for agent softcatala

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Edit `.env` to configure additional options:
 # LLM Model Configuration
 LLM_MODEL=llama3.2                  # Choose your model
 OLLAMA_URL=http://ollama:11434      # Ollama service URL
-CORS_ORIGINS=http://localhost:3000  # Allowed origins
+CORS_ORIGINS=http://localhost:3000,https://ccoreilly.github.io  # Allowed origins
 
 # Agent Configuration
 AGENT_TYPE=softcatala_english       # Agent type: softcatala_english (default) or softcatala_catalan

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,7 +30,7 @@ export OPENAI_KEY=your_openai_api_key
 export OPENROUTER_API_KEY=your_openrouter_api_key
 
 # Optional configurations
-export CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+export CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://ccoreilly.github.io
 export TELEGRAM_BOT_TOKEN=your_telegram_bot_token
 export TELEGRAM_MAX_USER_MESSAGES=20
 export SEARCH_API_KEY=your_search_api_key
@@ -61,7 +61,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key
 # ZHIPUAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
 
 # Optional: CORS configuration
-CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://ccoreilly.github.io
 
 # Optional: Telegram Bot Configuration
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token

--- a/backend/main.py
+++ b/backend/main.py
@@ -61,7 +61,7 @@ app = FastAPI(title="API de l'Agent de Softcatalà", version="2.0.0")
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=os.getenv("CORS_ORIGINS", "http://localhost:3000").split(","),
+    allow_origins=os.getenv("CORS_ORIGINS", "http://localhost:3000,https://ccoreilly.github.io").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - OLLAMA_URL=http://ollama:11434
       - LLM_MODEL=${LLM_MODEL:-llama3.2}
-      - CORS_ORIGINS=http://localhost:3000,http://localhost:80
+      - CORS_ORIGINS=http://localhost:3000,http://localhost:80,https://ccoreilly.github.io
       - AGENT_TYPE=${AGENT_TYPE:-softcatala_english}
     depends_on:
       ollama:


### PR DESCRIPTION
Allow GitHub Pages frontend domain in CORS configuration to resolve cross-origin errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb24ef16-952d-4a44-a376-04d0a5172912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb24ef16-952d-4a44-a376-04d0a5172912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

